### PR TITLE
Use a single TextEdit for document replace on formatting

### DIFF
--- a/pkg/lsp/handler.go
+++ b/pkg/lsp/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,8 +12,6 @@ import (
 	"github.com/carlverge/jsonnet-lsp/pkg/analysis"
 	"github.com/google/go-jsonnet/ast"
 	"github.com/google/go-jsonnet/formatter"
-	"github.com/hexops/gotextdiff/myers"
-	"github.com/hexops/gotextdiff/span"
 	"go.lsp.dev/jsonrpc2"
 	"go.lsp.dev/protocol"
 	"go.lsp.dev/uri"
@@ -514,7 +513,6 @@ func (s *Server) Formatting(ctx context.Context, params *protocol.DocumentFormat
 	if err != nil {
 		return []protocol.TextEdit{}, nil
 	}
-	edits := myers.ComputeEdits(span.URI(""), current.Contents, out)
 
-	return textEditToProto(edits), nil
+	return []protocol.TextEdit{{Range: protocol.Range{End: protocol.Position{Line: math.MaxInt32}}, NewText: string(out)}}, nil
 }

--- a/pkg/lsp/lsp.go
+++ b/pkg/lsp/lsp.go
@@ -312,20 +312,6 @@ func convChangeEvents(events []protocol.TextDocumentContentChangeEvent) []gotext
 	return res
 }
 
-func textEditToProto(edits []gotextdiff.TextEdit) []protocol.TextEdit {
-	res := make([]protocol.TextEdit, len(edits))
-	for i, ed := range edits {
-		res[i] = protocol.TextEdit{
-			Range: protocol.Range{
-				Start: protocol.Position{Line: uint32(ed.Span.Start().Line()) - 1, Character: uint32(ed.Span.Start().Column() - 1)},
-				End:   protocol.Position{Line: uint32(ed.Span.End().Line()) - 1, Character: uint32(ed.Span.End().Column() - 1)},
-			},
-			NewText: ed.NewText,
-		}
-	}
-	return res
-}
-
 type ParseResult struct {
 	Root ast.Node
 	Err  error


### PR DESCRIPTION
This was the behaviour before https://github.com/carlverge/jsonnet-lsp/commit/56d735eae06a5fdf3690616c202d361ccd8afb4c where we started to send multiple `TextEdit`s in an attempt to make the formatting work with IntelliJ.

Turns out the problem was just some parsing issue. From the below exception, it seems like it was not happy to accept `math.MaxUint32` (probably because under the hood it parses into a Java `int`, which is always signed). Using `math.MaxInt32` seems to work just fine. All I did was to revert to the previous behaviour and change MaxUint32 to MaxInt32.
```
2023-04-19 20:58:24,244 [1022255]   WARN - o.e.l.j.RemoteEndpoint - Issue found in NotificationMessage: Message could not be parsed.
com.google.gson.JsonSyntaxException: java.lang.NumberFormatException: Expected an int but was 4294967295 at line 1 column 164 path $.params.version
	at com.google.gson.internal.bind.TypeAdapters$7.read(TypeAdapters.java:227)
	at com.google.gson.internal.bind.TypeAdapters$7.read(TypeAdapters.java:217)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:129)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:220)
	at com.google.gson.Gson.fromJson(Gson.java:888)
	at org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter.fromJson(MessageTypeAdapter.java:329)
	at org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter.parseParams(MessageTypeAdapter.java:249)
	at org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter.read(MessageTypeAdapter.java:119)
	at org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter.read(MessageTypeAdapter.java:55)
	at com.google.gson.Gson.fromJson(Gson.java:888)
	at org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler.parseMessage(MessageJsonHandler.java:119)
	at org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler.parseMessage(MessageJsonHandler.java:114)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:193)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:94)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:113)
```