### PR TITLE
Release on Ubuntu 20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3.6.0


### PR DESCRIPTION
Right now one can't run the LSP binary on Ubuntu 20 because of an older version of libc:

```
[Error - 9:33:57 AM] The Jsonnet Language Server server crashed 5 times in the last 3 minutes. The server will not be restarted. See the output for more information.
/home/gabriel.russo/.vscode-server/extensions/cverge.jsonnet-lsp-0.2.10/jsonnet-lsp_linux_x64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/gabriel.russo/.vscode-server/extensions/cverge.jsonnet-lsp-0.2.10/jsonnet-lsp_linux_x64)
/home/gabriel.russo/.vscode-server/extensions/cverge.jsonnet-lsp-0.2.10/jsonnet-lsp_linux_x64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/gabriel.russo/.vscode-server/extensions/cverge.jsonnet-lsp-0.2.10/jsonnet-lsp_linux_x64)
```